### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,4 +18,4 @@ Also, it assumes you have `Cl.Accordion`_ installed in your project.
 Usage
 -----
 
-.. _Cl.Accordion: http://classjs-plugins.readthedocs.org/en/latest/src/cl.accordion.html
+.. _Cl.Accordion: https://classjs-plugins.readthedocs.io/en/latest/src/cl.accordion.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.